### PR TITLE
support typescript

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -5,10 +5,12 @@
         "node": "8.0.0"
       }
     }],
+    ["@babel/preset-typescript"],
     ["@babel/preset-react"]
   ],
   "plugins": [
     ["@babel/plugin-proposal-object-rest-spread"],
-    ["@babel/plugin-proposal-decorators", { "legacy": true }]
+    ["@babel/plugin-proposal-decorators", { "legacy": true }],
+    ["@babel/plugin-proposal-class-properties"]
   ]
 }

--- a/bin/boring-cli.js
+++ b/bin/boring-cli.js
@@ -1,10 +1,4 @@
 #!/usr/bin/env node
-const fs_extra = require('fs-extra');
-const path = require('path')
-const paths = require('../dist/node_modules/paths')
-const child_process = require('child_process')
-const fs = require('fs');
-
 let ran = false;
 
 function makeCmd(mod) {

--- a/bin/boring-cli.js
+++ b/bin/boring-cli.js
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+const fs_extra = require('fs-extra');
+const path = require('path')
+const paths = require('../dist/node_modules/paths')
+const child_process = require('child_process')
+const fs = require('fs');
+
+let ran = false;
+
+function makeCmd(mod) {
+  return function exec(argv) {
+    ran = true;
+    require('./' + mod)(argv)
+      .then((result = {status: 1}) => {
+        process.exit(result.status);
+      })
+      .catch(e => {
+        process.exit(1);
+      })
+  }
+}
+
+require('yargs')
+  .usage('$0 <cmd> [cmd-args]')
+  .command('type-check', 'Runs tsc against your projects TypeScript', makeCmd('boring-tsc'))
+  .command('tsc', '(Alias for type-check)', makeCmd('boring-tsc'))
+  .command('build-client', 'Run webpack on your project\'s web client', makeCmd('build-client'))
+  .command('build-node', 'Babel (ES7 + TypeScript) on your project\'s server', makeCmd('build-node'))
+  .command('up', 'Run `docker-compose up` to launch infrastructure such as reverse proxy', makeCmd('docker-compose-up'))
+  .command('down', 'Run `docker-compose down` to tear down infrastructure', makeCmd('docker-compose-down'))
+  .demandCommand(1)
+  .help()
+  .argv;
+
+if (!ran) {
+  console.log('No valid <cmd> given, please run `boring help` for a list of commands');
+}

--- a/bin/boring-tsc.js
+++ b/bin/boring-tsc.js
@@ -6,7 +6,7 @@ const child_process = require('child_process')
 const fs = require('fs');
 
 
-async function run() {
+async function run(argv) {
 
   let tscPath =  '/../node_modules/.bin/tsc';
   try {
@@ -21,6 +21,10 @@ async function run() {
     '--p', 
     path.normalize(process.cwd())
   ];
+
+  if (argv.watch) {
+    args.push('--watch')
+  }
   console.log('tcs ', args.join(' '));
   
   return child_process.spawnSync(path.normalize(__dirname+tscPath), args,
@@ -32,7 +36,7 @@ async function run() {
 
 }
 
-module.exports = function(argv) {
+module.exports = function(args) {
   try {
     try {
       fs.statSync(process.cwd() +  '/tsconfig.json');
@@ -42,7 +46,7 @@ module.exports = function(argv) {
       console.log(`Copying ${path.resolve(__dirname, '../tsconfig.json')} -> ${path.resolve(process.cwd(), '/tsconfig.json, feel free to edit this and make it your own')}`);
       fs.copyFileSync(path.resolve(__dirname, '../tsconfig.json'), process.cwd() +  '/tsconfig.json');
     }
-    return run();
+    return run(args.argv);
   }
   catch(e) {
     console.error('There was a problem the boring command', e);

--- a/bin/boring-tsc.js
+++ b/bin/boring-tsc.js
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+const fs_extra = require('fs-extra');
+const path = require('path')
+const paths = require('../dist/node_modules/paths')
+const child_process = require('child_process')
+const fs = require('fs');
+
+
+async function run() {
+
+  let tscPath =  '/../node_modules/.bin/tsc';
+  try {
+    fs.statSync(path.normalize(__dirname+tscPath));
+  } catch(e) {    
+    tscPath =  '/../../.bin/tsc';
+    fs.statSync(path.normalize(__dirname+tscPath));
+  }
+
+  const args = [
+    '--noEmit',
+    '--p', 
+    path.normalize(process.cwd())
+  ];
+  console.log('tcs ', args.join(' '));
+  
+  return child_process.spawnSync(path.normalize(__dirname+tscPath), args,
+    {
+      stdio: [process.stdin, process.stdout, process.stderr],
+      cwd: process.cwd()
+    }
+  ); 
+
+}
+
+module.exports = function(argv) {
+  try {
+    try {
+      fs.statSync(process.cwd() +  '/tsconfig.json');
+      console.log('tsconfig.json found in ' + process.cwd());
+    }
+    catch(e) {
+      console.log(`Copying ${path.resolve(__dirname, '../tsconfig.json')} -> ${path.resolve(process.cwd(), '/tsconfig.json, feel free to edit this and make it your own')}`);
+      fs.copyFileSync(path.resolve(__dirname, '../tsconfig.json'), process.cwd() +  '/tsconfig.json');
+    }
+    return run();
+  }
+  catch(e) {
+    console.error('There was a problem the boring command', e);
+    return Promise.reject({status: 1});
+  }
+}

--- a/bin/build-client.js
+++ b/bin/build-client.js
@@ -3,7 +3,6 @@
 // Do this as the first thing so that any code reading it knows the right env.
 process.env.BABEL_ENV = 'production';
 process.env.NODE_ENV = 'production';
-process.env['boring.paths.base_app_path']='src';
 
 
 // Makes the script crash on unhandled rejections instead of silently

--- a/bin/build-node.js
+++ b/bin/build-node.js
@@ -1,4 +1,7 @@
 #!/usr/bin/env node
+process.env.BABEL_ENV = 'production';
+process.env.NODE_ENV = 'production';
+
 const fs_extra = require('fs-extra');
 const path = require('path')
 const paths = require('../dist/node_modules/paths')

--- a/bin/build-node.js
+++ b/bin/build-node.js
@@ -16,19 +16,33 @@ async function build() {
     fs.statSync(path.normalize(__dirname+babelPath));
   }
   
-  child_process.spawn(path.normalize(__dirname+babelPath), ['--no-babelrc', 'src', '-d', paths.app_dist, '--source-maps', '--copy-files', 
-    `--presets=${paths.boring_dir}dist/build/wrapped-babel-env,@babel/preset-react`, 
-    `--plugins=@babel/plugin-proposal-object-rest-spread,${paths.boring_dir}dist/build/wrapped-babel-plugin-proposal-decorators`],
+  const args = [
+    '--no-babelrc', 
+    'src', '-d', paths.app_dist, 
+    `--extensions=.ts,.tsx,.js,.jsx`,
+    '--source-maps', 
+    '--copy-files', 
+    `--presets=${paths.boring_dir}dist/build/wrapped-babel-env,@babel/preset-typescript,@babel/preset-react`, 
+    `--plugins=@babel/plugin-proposal-object-rest-spread,${paths.boring_dir}dist/build/wrapped-babel-plugin-proposal-decorators,@babel/plugin-proposal-class-properties`,
+    ];
+
+  console.log('babel ' +args.join(' '));
+
+  return child_process.spawnSync(path.normalize(__dirname+babelPath), args,
     {
-      stdio: [process.stdin, process.stdout, process.stderr]
+      stdio: [process.stdin, process.stdout, process.stderr],
+      cwd: process.cwd()
     }
   ); 
 
-}
+} 
 
-try {
-  build();
-}
-catch(e) {
-  console.error('There was a problem running babel on your project', e);
+module.exports = function(argv) {
+  try {
+    return build();
+  }
+  catch(e) {
+    console.error('There was a problem running babel on your project', e);
+    return Promise.reject({status: 1});
+  }
 }

--- a/bin/docker-compose-down.js
+++ b/bin/docker-compose-down.js
@@ -9,7 +9,7 @@ async function build() {
 
   fs_extra.emptyDirSync(paths.app_dist);
 
-  child_process.spawn('docker-compose', ['down'],
+  return child_process.spawnSync('docker-compose', ['down'],
     {
       stdio: [process.stdin, process.stdout, process.stderr],
       cwd: path.normalize(__dirname + '/..')
@@ -18,9 +18,12 @@ async function build() {
 
 }
 
-try {
-  build();
-}
-catch(e) {
-  console.error('There was a problem booting up docker', e);
+module.exports = function(argv) {
+  try {
+    return build();
+  }
+  catch(e) {
+    console.error('There was a problem booting up docker', e);
+    return Promise.reject(e);
+  }
 }

--- a/bin/docker-compose-up.js
+++ b/bin/docker-compose-up.js
@@ -9,7 +9,7 @@ async function build() {
 
   fs_extra.emptyDirSync(paths.app_dist);
 
-  child_process.spawn('docker-compose', ['up', '-d'],
+  return child_process.spawnSync('docker-compose', ['up', '-d'],
     {
       stdio: [process.stdin, process.stdout, process.stderr],
       cwd: path.normalize(__dirname + '/..')
@@ -18,9 +18,12 @@ async function build() {
 
 }
 
-try {
-  build();
-}
-catch(e) {
-  console.error('There was a problem booting up docker', e);
+module.exports = function(argv) {
+  try {
+    return build();
+  }
+  catch(e) {
+    console.error('There was a problem booting up docker', e);
+    return Promise.reject(e);
+  }
 }

--- a/config/runtime/webpack.config.dev.js
+++ b/config/runtime/webpack.config.dev.js
@@ -10,8 +10,6 @@ const ModuleScopePlugin = require('react-dev-utils/ModuleScopePlugin');
 const ProgressBarPlugin = require('progress-bar-webpack-plugin');
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 
-
-
 // Webpack uses `publicPath` to determine where the app is being served from.
 // In development, we always serve from the root. This makes config easier.
 const publicPath = '/';
@@ -69,12 +67,13 @@ module.exports = {
     // https://github.com/facebookincubator/create-react-app/issues/290
     // `web` extension prefixes have been added for better support
     // for React Native Web.
-    extensions: ['.web.js', '.mjs', '.js', '.json', '.web.jsx', '.jsx'],
+    extensions: ['.web.js', '.mjs', '.js', '.json', '.web.jsx', '.jsx', '.ts', '.tsx'],
     alias: {
 
       // Support React Native Web
       // https://www.smashingmagazine.com/2016/08/a-glimpse-into-the-future-with-react-native-for-web/
       'react-native': 'react-native-web',
+      'modules': path.resolve(process.cwd(), 'src/modules'),
     },
     plugins: [
       // Prevents users from importing files from outside of src/ (or node_modules/).
@@ -106,7 +105,7 @@ module.exports = {
           },
           // Process JS with Babel.
           {
-            test: /\.(js|jsx|mjs)$/,
+            test: /\.(js|jsx|mjs|ts|tsx)$/,
             include: paths.app_src,
             loader: require.resolve('babel-loader'),
             options: {
@@ -126,11 +125,13 @@ module.exports = {
                    // "node": "10.9.0",
                   }
                 }],
+                ["@babel/preset-typescript"],
                 ["@babel/preset-react"]
               ],
               "plugins": [
                 ["@babel/plugin-proposal-object-rest-spread"],
-                ["@babel/plugin-proposal-decorators", { "legacy": true }]
+                ["@babel/plugin-proposal-decorators", { "legacy": true }],
+                ["@babel/plugin-proposal-class-properties"]
               ]
             },
           },

--- a/config/runtime/webpack.config.prod.js
+++ b/config/runtime/webpack.config.prod.js
@@ -66,12 +66,13 @@ module.exports = {
     // https://github.com/facebookincubator/create-react-app/issues/290
     // `web` extension prefixes have been added for better support
     // for React Native Web.
-    extensions: ['.web.js', '.mjs', '.js', '.json', '.web.jsx', '.jsx'],
+    extensions: ['.web.js', '.mjs', '.js', '.json', '.web.jsx', '.jsx', '.ts', 'tsx'],
     alias: {
 
       // Support React Native Web
       // https://www.smashingmagazine.com/2016/08/a-glimpse-into-the-future-with-react-native-for-web/
       'react-native': 'react-native-web',
+      'modules': path.resolve(process.cwd(), 'src/modules'),
     },
     plugins: [
       // Prevents users from importing files from outside of src/ (or node_modules/).
@@ -102,11 +103,12 @@ module.exports = {
           },
           // Process JS with Babel.
           {
-            test: /\.(js|jsx|mjs)$/,
+            test: /\.(js|jsx|mjs|ts|tsx)$/,
             include: paths.app_src,
             loader: require.resolve('babel-loader'),
             options: {
-                // This is a feature of `babel-loader` for webpack (not Babel itself).
+
+              // This is a feature of `babel-loader` for webpack (not Babel itself).
               // It enables caching results in ./node_modules/.cache/babel-loader/
               // directory for faster rebuilds.
               cacheDirectory: true,
@@ -121,11 +123,13 @@ module.exports = {
                    // "node": "10.9.0",
                   }
                 }],
+                ["@babel/preset-typescript"],
                 ["@babel/preset-react"]
               ],
               "plugins": [
                 ["@babel/plugin-proposal-object-rest-spread"],
-                ["@babel/plugin-proposal-decorators", { "legacy": true }]
+                ["@babel/plugin-proposal-decorators", { "legacy": true }],
+                ["@babel/plugin-proposal-class-properties"]
               ]
             },
           },

--- a/package-lock.json
+++ b/package-lock.json
@@ -4690,9 +4690,9 @@
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
     },
     "injecture": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/injecture/-/injecture-1.2.2.tgz",
-      "integrity": "sha512-xmOVIWfWYY+/4bmhY8HFK18ln2anKQmLkZzjaGs4df5dvSkjqhZtnCctFIjTbHGa9V3V9ef7EdENrDqXt+IsCA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/injecture/-/injecture-1.3.0.tgz",
+      "integrity": "sha512-gwvJ4iVATgGwtjiwiNE0+L4hYBZcugIXY5sqMH2u6RBbFW6uC/X1ewCmbxfMb8K7BP2/RhYcRVqmHiCWxv7RYw==",
       "requires": {
         "camelcase": "^5.0.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "boringbits",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -111,6 +111,18 @@
         "@babel/helper-hoist-variables": "^7.0.0",
         "@babel/traverse": "^7.1.0",
         "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-create-class-features-plugin": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.2.1.tgz",
+      "integrity": "sha512-EsEP7XLFmcJHjcuFYBxYD1FkP0irC8C9fsrt2tX/jrAi/eTnFI6DOPgVFb+WREeg1GboF+Ib+nCHbGBodyAXSg==",
+      "requires": {
+        "@babel/helper-function-name": "^7.1.0",
+        "@babel/helper-member-expression-to-functions": "^7.0.0",
+        "@babel/helper-optimise-call-expression": "^7.0.0",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-replace-supers": "^7.1.0"
       }
     },
     "@babel/helper-define-map": {
@@ -295,16 +307,12 @@
       }
     },
     "@babel/plugin-proposal-class-properties": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.1.0.tgz",
-      "integrity": "sha512-/PCJWN+CKt5v1xcGn4vnuu13QDoV+P7NcICP44BoonAJoPSGwVkgrXihFIQGiEjjPlUDBIw1cM7wYFLARS2/hw==",
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.2.1.tgz",
+      "integrity": "sha512-/4FKFChkQ2Jgb8lBDsvFX496YTi7UWTetVgS8oJUpX1e/DlaoeEK57At27ug8Hu2zI2g8bzkJ+8k9qrHZRPGPA==",
       "requires": {
-        "@babel/helper-function-name": "^7.1.0",
-        "@babel/helper-member-expression-to-functions": "^7.0.0",
-        "@babel/helper-optimise-call-expression": "^7.0.0",
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-replace-supers": "^7.1.0",
-        "@babel/plugin-syntax-class-properties": "^7.0.0"
+        "@babel/helper-create-class-features-plugin": "^7.2.1",
+        "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-proposal-decorators": {
@@ -363,14 +371,6 @@
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
-    "@babel/plugin-syntax-class-properties": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.0.0.tgz",
-      "integrity": "sha512-cR12g0Qzn4sgkjrbrzWy2GE7m9vMl/sFkqZ3gIpAQdrvPDnLM8180i+ANDFIXfjHo9aqp0ccJlQ0QNZcFUbf9w==",
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
-      }
-    },
     "@babel/plugin-syntax-decorators": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.1.0.tgz",
@@ -407,6 +407,14 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.0.0.tgz",
       "integrity": "sha512-Wc+HVvwjcq5qBg1w5RG9o9RVzmCaAg/Vp0erHCKpAYV8La6I94o4GQAmFYNmkzoMO6gzoOSulpKeSSz6mPEoZw==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-syntax-typescript": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.2.0.tgz",
+      "integrity": "sha512-WhKr6yu6yGpGcNMVgIBuI9MkredpVc7Y3YR4UzEZmDztHoL6wV56YBHLhWnjO1EvId1B32HrD3DRFc+zSoKI1g==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
@@ -679,6 +687,15 @@
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
+    "@babel/plugin-transform-typescript": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.2.0.tgz",
+      "integrity": "sha512-EnI7i2/gJ7ZNr2MuyvN2Hu+BHJENlxWte5XygPvfj/MbvtOkWor9zcnHpMMQL2YYaaCcqtIvJUyJ7QVfoGs7ew==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-typescript": "^7.2.0"
+      }
+    },
     "@babel/plugin-transform-unicode-regex": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.0.0.tgz",
@@ -756,6 +773,15 @@
         "@babel/plugin-transform-react-jsx": "^7.0.0",
         "@babel/plugin-transform-react-jsx-self": "^7.0.0",
         "@babel/plugin-transform-react-jsx-source": "^7.0.0"
+      }
+    },
+    "@babel/preset-typescript": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.1.0.tgz",
+      "integrity": "sha512-LYveByuF9AOM8WrsNne5+N79k1YxjNB6gmpCQsnuSBAcV8QUeB+ZUxQzL7Rz7HksPbahymKkq2qBR+o36ggFZA==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-transform-typescript": "^7.1.0"
       }
     },
     "@babel/register": {
@@ -915,6 +941,11 @@
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-0.0.30.tgz",
       "integrity": "sha512-orGL5LXERPYsLov6CWs3Fh6203+dXzJkR7OnddIr2514Hsecwc8xRpzCapshBbKFImCsvS/mk6+FWiN5LyZJAQ=="
     },
+    "@types/history": {
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.2.tgz",
+      "integrity": "sha512-ui3WwXmjTaY73fOQ3/m3nnajU/Orhi6cEu5rzX+BrAAJxa3eITXZ5ch9suPqtM03OWhAHhPSyBGCN4UKoxO20Q=="
+    },
     "@types/jss": {
       "version": "9.5.7",
       "resolved": "https://registry.npmjs.org/@types/jss/-/jss-9.5.7.tgz",
@@ -923,6 +954,11 @@
         "csstype": "^2.0.0",
         "indefinite-observable": "^1.0.1"
       }
+    },
+    "@types/node": {
+      "version": "10.12.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.12.tgz",
+      "integrity": "sha512-Pr+6JRiKkfsFvmU/LK68oBRCQeEg36TyAbPhc2xpez24OOZZCuoIhWGTd39VZy6nGafSbxzGouFPTFD/rR1A0A=="
     },
     "@types/prop-types": {
       "version": "15.5.6",
@@ -1213,6 +1249,11 @@
         "micromatch": "^3.1.4",
         "normalize-path": "^2.1.1"
       }
+    },
+    "app-module-path": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/app-module-path/-/app-module-path-2.2.0.tgz",
+      "integrity": "sha1-ZBqlXft9am8KgUHEucCqULbCTdU="
     },
     "aproba": {
       "version": "1.2.0",
@@ -8101,6 +8142,11 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+    },
+    "typescript": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.1.tgz",
+      "integrity": "sha512-jw7P2z/h6aPT4AENXDGjcfHTu5CSqzsbZc6YlUIebTyBAq8XaKp78x7VcSh30xwSCcsu5irZkYZUSFP1MrAMbg=="
     },
     "ua-parser-js": {
       "version": "0.7.19",

--- a/package.json
+++ b/package.json
@@ -4,18 +4,17 @@
   "description": "Frameworks should be boring, applications they build should be exciting",
   "main": "dist/boring.js",
   "scripts": {
-    "test": "NODE_ENV=unit-tests mocha node_modules/mocha/bin/_mocha --require @babel/register $(find ./src -name '*-test.js')",
-    "test-debug": "node --inspect-brk=9229 node_modules/mocha/bin/_mocha  --require @babel/register $(find ./src -name '*-test.js')",
+    "type-check": "tsc --noEmit",
+    "test": "NODE_ENV=unit-tests mocha node_modules/mocha/bin/_mocha --require ./src/babel_register $(find ./src -name '*-test.js')",
+    "test-dist": "NODE_ENV=unit-tests mocha node_modules/mocha/bin/_mocha $(find ./dist -name '*-test.js')",
+    "test-debug": "node --inspect-brk=9229 node_modules/mocha/bin/_mocha  --require ./src/babel_register $(find ./src -name '*-test.js')",
     "test-watch": "nodemon --watch src --exec \"npm test | npx bunyan\"",
     "test-build": "nodemon --watch src --exec \"npm test && npm run build\"",
-    "build": "rm -rf dist && babel src -d dist --source-maps",
+    "build": "rm -rf dist && babel src -d dist --extensions \".ts,.tsx,.js,.jsx\" --source-maps",
     "prepublishOnly": "npm test && npm run build"
   },
   "bin": {
-    "boring-build-node": "./bin/build-node.js",
-    "boring-build-client": "./bin/build-client.js",
-    "boring-up": "./bin/docker-compose-up.js",
-    "boring-down": "./bin/docker-compose-down.js"
+    "boring": "./bin/boring-cli"
   },
   "author": "Ryan Stevens",
   "license": "UNLICENSED",
@@ -31,15 +30,19 @@
   "dependencies": {
     "@babel/cli": "^7.0.0",
     "@babel/core": "^7.0.0",
-    "@babel/plugin-proposal-class-properties": "^7.1.0",
+    "@babel/plugin-proposal-class-properties": "^7.2.1",
     "@babel/plugin-proposal-decorators": "^7.0.0",
     "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
     "@babel/polyfill": "^7.0.0",
     "@babel/preset-env": "^7.0.0",
     "@babel/preset-react": "^7.0.0",
+    "@babel/preset-typescript": "^7.1.0",
     "@babel/register": "^7.0.0",
     "@babel/runtime": "^7.1.2",
     "@material-ui/core": "^3.6.0",
+    "@types/history": "^4.7.2",
+    "@types/node": "^10.12.12",
+    "app-module-path": "^2.2.0",
     "async": "^2.6.1",
     "autoprefixer": "^9.1.5",
     "babel-loader": "^8.0.2",
@@ -79,6 +82,7 @@
     "redux": "^4.0.1",
     "serve-static": "^1.13.2",
     "style-loader": "^0.23.0",
+    "typescript": "^3.2.1",
     "understudy": "^4.1.0",
     "url-loader": "^1.1.1",
     "webpack": "^4.18.0",
@@ -86,7 +90,8 @@
     "webpack-cli": "^3.1.0",
     "webpack-dev-middleware": "^3.3.0",
     "webpack-hot-middleware": "^2.23.1",
-    "webpack-manifest-plugin": "^2.0.3"
+    "webpack-manifest-plugin": "^2.0.3",
+    "yargs": "^12.0.5"
   },
   "nodemon": {
     "ignoreRoot": [

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "glob": "^7.1.3",
     "healthy": "^1.0.2",
     "history": "^4.7.2",
-    "injecture": "^1.2.2",
+    "injecture": "^1.3.0",
     "mini-css-extract-plugin": "^0.4.2",
     "moment": "^2.22.2",
     "nodemon": "^1.18.4",

--- a/register.js
+++ b/register.js
@@ -1,0 +1,16 @@
+/**
+ * Will babelify a code base using
+ * boring's presets.  
+ * 
+ * This is intended primarily for dev tasks 
+ * such as unit tests.  You should 
+ * generally not need to use this 
+ * in your main application during 
+ * 
+ * Usage Examples: 
+ * 
+ * - if (dev) require('boringbits/register');
+ * - node node_modules/mocha/bin/_mocha  --require boringbits/register src/tests/my-test.js
+ */
+
+ require('./dist/babel_register');

--- a/src/babel_register.js
+++ b/src/babel_register.js
@@ -1,4 +1,4 @@
-const config = require('boring-config');
+var config = require('boring-config');
 
 require('@babel/register')({
   // ignore: [],
@@ -8,12 +8,15 @@ require('@babel/register')({
          "node": config.get('boring.babel.node_target', '10.9.0')
        }
      }],
+     ["@babel/preset-typescript"],
      '@babel/preset-react'
    ],
+   "extensions": [".jsx", ".js", ".tsx", ".ts"],
    "plugins": [
      "@babel/plugin-proposal-object-rest-spread",
      ["@babel/plugin-proposal-decorators", {
        legacy: true
-     }]
+     }],
+     ["@babel/plugin-proposal-class-properties"],
    ]
  })

--- a/src/boring.js
+++ b/src/boring.js
@@ -1,3 +1,4 @@
+require('app-module-path').addPath(process.cwd() + '/src');
 
 const config = require('boring-config');
 const logger = require('boring-logger');

--- a/src/test/boring-test.js
+++ b/src/test/boring-test.js
@@ -1,6 +1,6 @@
 var assert = require('assert');
 
-describe.only('Boring entrypoint', function() {
+describe('Boring entrypoint', function() {
   
   this.timeout(5000);
   

--- a/src/test/boring-test.js
+++ b/src/test/boring-test.js
@@ -1,6 +1,6 @@
 var assert = require('assert');
 
-describe('Boring entrypoint', function() {
+describe.only('Boring entrypoint', function() {
   
   this.timeout(5000);
   

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "noEmit": true,
+    "baseUrl": "./src",
+    "target": "esnext",     
+    "sourceMap": true,   
+    "module": "commonjs",  
+    "declaration": true,   
+    "noImplicitAny": false,
+    "experimentalDecorators": true
+  },
+  "include": [
+    "src"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}


### PR DESCRIPTION
@josheverett This PR does a handful of very dev task'y things.  

* I added a typescript loader to babel so a programmer can add a *.ts file to their project and it magically works.  
  * I generally went from this guide https://iamturns.com/typescript-babel/
  * Yes, you can mix ES7 with TypeScript (what could go wrong), OR you can be all ES6/7 (via babel) or all TS, or mixed, PROGRAMMERS choice!
* I exposed a `register` module on the project level so people can babel their code to boring's preset if they want to not have boring server magically do it for you (but it's mostly for unit tests)
* There now is a bin of simply `boring` (rather than `boring-client-build`, `boring-node-build`, etc) that aggregates all the old command into one executable.  This way we can have a common way to eventually pass in arguments into commands so at some point when we say `boring up --proxy` only haproxy will launch and not dynomodb