### PR TITLE
first yeoman generator working!  bare bones version

### DIFF
--- a/bin/boring-cli.js
+++ b/bin/boring-cli.js
@@ -25,6 +25,7 @@ require('yargs')
     .command('up', 'Run `docker-compose up` to launch infrastructure such as reverse proxy', makeCmd('docker-compose-up'))
     .command('down', 'Run `docker-compose down` to tear down infrastructure', makeCmd('docker-compose-down'))
     .command('yo', 'Generate routes / views / app structure', makeCmd('yo'))
+    .command('generate', 'Alias to `yo`', makeCmd('yo'))
     .demandCommand(1)
     .help()
     .argv;

--- a/isNode.js
+++ b/isNode.js
@@ -1,0 +1,2 @@
+const isNode = require('detect-node');
+module.exports = isNode;

--- a/src/babel_register.js
+++ b/src/babel_register.js
@@ -5,7 +5,7 @@ require('@babel/register')({
   'presets': [
     ['@babel/preset-env', {
       'targets': {
-        'node': config.get('boring.babel.node_target', '8.10.0')
+        'node': config.get('boring.babel.node_target', '8.10.0'),
       },
     }],
     ['@babel/preset-typescript'],

--- a/src/boring.js
+++ b/src/boring.js
@@ -1,24 +1,26 @@
 
 const config = require('boring-config');
 const logger = require('boring-logger');
-const node_app_path = require('app-module-path');
+const nodeAppPath = require('app-module-path');
+const isNode = require('detect-node');
+
 
 const isDevelopment = config.get('boring.isDevelopment', true);
 
-node_app_path.addPath(process.cwd() + (isDevelopment ? '/src' : '/dist'));
-
+nodeAppPath.addPath(process.cwd() + (isDevelopment ? '/src' : '/dist'));
 
 if (config.get('boring.babel.register_app') === true) {
   logger.info('babelifying codebase via @babel/register');
   require('./babel_register');
 }
 
-import Server from './lib/server';
-import injecture from 'injecture';
+const Server = require('./lib/server');
+const injecture = require('injecture');
 
 module.exports = {
   Server,
   injecture,
   config,
   logger,
+  isNode,
 };

--- a/src/build/wrapped-babel-env.js
+++ b/src/build/wrapped-babel-env.js
@@ -6,7 +6,7 @@ module.exports = function(...args) {
   const dirname = args[2]; 
   
   options.targets = {
-    "node": "10.9.0"
+    "node": "8"
   }
   return preset.default(api, options, dirname);
 }

--- a/src/lib/init-hooks/core-hooks/react/dynamicComponents/index.js
+++ b/src/lib/init-hooks/core-hooks/react/dynamicComponents/index.js
@@ -7,17 +7,6 @@ import beforeEntryLoader from './beforeEntryLoader';
 function makeConainerCode({path, importPath} = container) {
   const name = path.replace(/\//g, '');
 
-  /*
-  // TODO: I had to backpedal a bit on
-  // making these routez lazy loaded via
-  // webpacks optimization chunks.
-  // Should be too hard to renable,
-  // was just having some trouble keeping
-  // hot reload working which is more of a
-  // priority
-  
-  */
-
   return `
   console.log('setting dynamic target: ${name}');
   (function() {

--- a/src/lib/init-hooks/core-hooks/webpack-dev/createWebpackStack.js
+++ b/src/lib/init-hooks/core-hooks/webpack-dev/createWebpackStack.js
@@ -58,8 +58,10 @@ module.exports = function createWebpackStack(BoringInjections) {
         return collector;
       }, {});
 
-
-      if (config.get('boring.useWebpackDevServer')) {
+      if (config.get('boring.useWebpackDevServer') &&
+        // only bother to run webpack if we someone
+        // has actually used the @entrypoint decorator
+        Object.keys(webpack_config.entry).length > 0) {
         const webpack = require('webpack');
         const compiler = webpack(webpack_config);
 

--- a/src/lib/server/index.js
+++ b/src/lib/server/index.js
@@ -1,3 +1,5 @@
+if (!process.env.NODE_ENV) process.env.NODE_ENV = 'development';
+
 const config = require('boring-config');
 const logger = require('boring-logger');
 const paths = require('paths');
@@ -10,30 +12,27 @@ async function startExpress(app, port) {
 }
 
 class BoringServer extends InitPipeline {
-  constructor() {
-    super();
-  }
 
   async start(options) {
 
-    const webpack_config_path = config.get('boring.isDevelopment', true) ?
+    const webpackConfig = config.get('boring.isDevelopment', true) ?
       paths.boring_webpack_dev_config : paths.boring_webpack_prod_config;
 
     const injections = await this.build(Object.assign({}, {
-      webpack_config: require(webpack_config_path)
+      webpack_config: require(webpackConfig),
     }, options));
 
     const port = process.env.PORT || config.get('boring.app.port');
     injections.port = port;
 
-    return await this.perform('listen', injections, async() => {
+    return await this.perform('listen', injections, async () => {
       await startExpress(this.app, port);
       logger.info('Listening on port ' + port);
 
       return injections;
-    })
+    });
 
   }
 }
 
-module.exports = BoringServer
+module.exports = BoringServer;

--- a/yo/generator/app/index.js
+++ b/yo/generator/app/index.js
@@ -1,32 +1,38 @@
 'use strict';
 const Generator = require('yeoman-generator');
 const chalk = require('chalk');
-const yosay = require('yosay');
 
 module.exports = class extends Generator {
+  initializing() {
+
+    const options = {
+      props: {},
+      processPrompt,
+    };
+
+    const prompt = this.prompt.bind(this);
+
+    async function processPrompt(promptObj, context, propToMerge) {
+      const answers = await prompt(promptObj);
+
+      if (!context) {
+        context = options;
+      }
+      if (!propToMerge) propToMerge = 'props';
+
+      Object.assign(context[propToMerge], answers);
+      return context[propToMerge];
+    }
+
+    this.composeWith(require.resolve('../server'), options);
+    this.composeWith(require.resolve('../page'), options);
+  }
+
   async prompting() {
+
     // Have Yeoman greet the user.
-    this.log(`\n\nWelcome to the very exciting ${chalk.red('generator-boring')} generator!\n\n`);
-
-    const answers = await this.prompt([{
-      type: 'input',
-      name: 'name',
-      message: 'Your project name',
-      default: this.appname, // Default to current folder name
-    }]);
-
-    this.log('app name', answers.name);
-  }
-
-  writing() {
-    // console.log(this.props);
-    // this.fs.copy(
-    //     this.templatePath('dummyfile.txt'),
-    //     this.destinationPath('dummyfile.txt')
-    // );
-  }
-
-  install() {
+    this.log('\n\nWelcome to the very exciting '+
+      `${chalk.red('boringbits')} generator!\n\n`);
 
   }
 };

--- a/yo/generator/page/index.js
+++ b/yo/generator/page/index.js
@@ -1,0 +1,49 @@
+'use strict';
+const Generator = require('yeoman-generator');
+
+
+module.exports = class extends Generator {
+
+  constructor(args, options) {
+    super(args, options);
+
+    this.props = this.options.props;
+    this.processPrompt = this.options.processPrompt;
+  }
+
+  async prompting() {
+
+    await this.processPrompt({
+      type: 'input',
+      name: 'pageName',
+      message: 'What is the name of the route you want to make',
+      default: 'home',
+    });
+
+    await this.processPrompt({
+      type: 'input',
+      name: 'path',
+      message: 'What is the url path',
+      default: '/',
+    });
+
+    this.props.pageName = this.props.pageName.replace(/\s+/g, '-');
+    this.props.className = this.props.pageName.charAt(0).toUpperCase() + this.props.pageName.substring(1);
+  }
+
+  async writing() {
+
+    this.fs.copyTpl(
+        this.templatePath('page.js'),
+        this.destinationPath(`src/server/routers/${this.props.pageName}.js`),
+        this.props
+    );
+
+    this.fs.copyTpl(
+        this.templatePath('app.js'),
+        this.destinationPath(`src/client/pages/${this.props.pageName}/entrypoint.js`),
+        this.props
+    );
+  }
+
+};

--- a/yo/generator/page/templates/app.js
+++ b/yo/generator/page/templates/app.js
@@ -1,0 +1,23 @@
+
+console.log('I\'m a vanilla javascript file, who needs a framework');
+
+// for fun change the name to see validate Hot Relaod is working
+const name = 'Josh';
+
+function printMsg(data) {
+  document.getElementById('root').innerHTML =
+  'Message from server<br />******************<br />' + data.msg;
+  return Promise.resolve();
+}
+
+fetch('/data.json', {
+  method: 'POST',
+  body: JSON.stringify({name}),
+  headers: {'Content-Type': 'application/json; charset=utf-8'},
+}).then(response => response.json())
+  .then(printMsg)
+  .catch(function(err) {
+    console.log('Fetch Error :-S', err);
+  });
+
+if (module.hot)  module.hot.accept((err) => console.log("error reloading", err));

--- a/yo/generator/page/templates/page.js
+++ b/yo/generator/page/templates/page.js
@@ -1,0 +1,60 @@
+
+module.exports = function setupRoute(/* dependencies from boring */ boring) {
+
+  const {
+    logger,
+    config,
+    decorators,
+  } = boring;
+
+  const {
+    endpoint,
+    post,
+    get,
+    entrypoint,
+  } = decorators.router;
+
+  // signals to boring this class has HTTP decortors as class methods
+  @endpoint()
+  class <%= className %> {
+
+    // The @get decorator is the primary mechanism to setup a route in boring
+    @post('<%= path %>data.json')
+    serve_<%= pageName %>_data(req, res) {
+      logger.info('Severing JSON for <%= pageName %>');
+      res.json({
+        msg: 'hello world, good to meet you ' + req.body.name
+      });
+    }
+
+    @get('<%= path %>')
+    @entrypoint('client/pages/<%= pageName %>/entrypoint.js')
+    serve_<%= pageName %>_get(req, res) {
+      logger.info('Severing JSON for <%= pageName %>');
+
+
+      const links = res.locals.pageInjections.headLinks || [];
+      const scripts = res.locals.pageInjections.bodyEndScripts || [];
+
+      res.send(`
+    <!DOCTYPE html>
+      <html style={{ height: '100%' }}>
+        <head>
+          ${links.map(link => {
+            return `<link rel="stylesheet" href="${link.href}" />`;
+          }).join('\n')}
+        </head>
+        <body style={{ height: '100%', padding: '0px', margin: '0px' }}>
+          <div style={{ width: '100%', height: '100%' }} id="root">
+
+          </div>
+          ${scripts.map(script => {
+            return `<script src="${script.src}"></script>`;
+          }).join('\n')}
+        </body>
+      </html>
+      `)
+    }
+  }
+
+};

--- a/yo/generator/server/copyConfigs.js
+++ b/yo/generator/server/copyConfigs.js
@@ -1,0 +1,53 @@
+const boringPackageJSON = require('../../../package.json');
+
+module.exports = async function() {
+
+  const pkgJson = {
+    name: this.options.props.projectName,
+    version: '1.0.0',
+    dependencies: {
+      boringbits: '^' + boringPackageJSON.version,
+    },
+    scripts: {
+      'start': 'npx boring start',
+      'build': 'npm run build-node && npm run build-client',
+      'build-node': 'npx boring build-node',
+      'build-client': 'npx boring build-client',
+      'tsc': 'npx boring type-check',
+      'type-check': 'npm run tsc',
+      'up': 'npx boring up',
+      'down': 'npx boring down',
+      'debug': 'npx boring debug',
+      'prepublishOnly': 'npm run build',
+    },
+  };
+
+  // Extend or create package.json file in destination path
+  this.fs.extendJSON(this.destinationPath('package.json'), pkgJson);
+
+
+  /**
+   * Copy configs
+   */
+  this.fs.copyTpl(
+      this.templatePath('config/default.js'),
+      this.destinationPath('config/default.js'),
+      this.options.props
+  );
+  this.fs.copyTpl(
+      this.templatePath('config/development.js'),
+      this.destinationPath('config/development.js'),
+      this.options.props
+  );
+  this.fs.copyTpl(
+      this.templatePath('config/staging.js'),
+      this.destinationPath('config/staging.js'),
+      this.options.props
+  );
+  this.fs.copyTpl(
+      this.templatePath('config/production.js'),
+      this.destinationPath('config/production.js'),
+      this.options.props
+  );
+
+};

--- a/yo/generator/server/index.js
+++ b/yo/generator/server/index.js
@@ -1,0 +1,52 @@
+'use strict';
+const Generator = require('yeoman-generator');
+const chalk = require('chalk');
+// const inquirer = require('inquirer');
+const copyConfigs = require('./copyConfigs');
+const makeApp = require('./makeApp');
+
+
+module.exports = class extends Generator {
+  constructor(args, options) {
+    super(args, options);
+    this.options = options;
+
+    this.props = this.options.props;
+    this.processPrompt = this.options.processPrompt;
+  }
+
+  async prompting() {
+
+    await this.processPrompt({
+      type: 'list',
+      name: 'scope',
+      message: 'What do you want to generate?',
+      choices: [
+        {name: 'Scaffold an entire boring app', value: 'all'},
+        {name: 'Add a component', value: 'component'},
+      ],
+    });
+
+    if (this.props.scope === 'all') {
+      await this.processPrompt({
+        type: 'input',
+        name: 'projectName',
+        message: 'What is the name of project',
+        default: this.appname, // Default to current folder name
+      });
+
+      this.props.projectName = this.props
+          .projectName.replace(/\s+/g, '-').toLowerCase();
+
+    }
+
+  }
+
+  async writing() {
+    if (this.props.scope === 'all') {
+      await copyConfigs.call(this);
+      await makeApp.call(this);
+    }
+  }
+
+};

--- a/yo/generator/server/makeApp.js
+++ b/yo/generator/server/makeApp.js
@@ -1,0 +1,9 @@
+
+module.exports = async function makeApp() {
+
+  this.fs.copyTpl(
+      this.templatePath('server/app.js'),
+      this.destinationPath('src/server/app.js'),
+      this.props
+  );
+};

--- a/yo/generator/server/templates/config/default.js
+++ b/yo/generator/server/templates/config/default.js
@@ -1,0 +1,50 @@
+/**
+ * The default.js config file is used
+ * by ALL environments regardless of
+ * the value set to NODE_ENV. Any config
+ * key overriden by an environments
+ * configuration will be overriden, so
+ * think of anything in this file as
+ * "defaults".
+ *
+ * For example, we can set a default value
+ * for the key foo.bar to "baz" like so
+ * ```
+ * {
+ *   foo: {
+ *      bar: 'baz',
+ *   }
+ * }
+ * ```
+ *
+ * The value of `baz` will be set on all
+ * enviornments.  If we wanted to override
+ * the value of foo.bar to 'beep' in ONLY
+ * production we would change production.js'
+ * config file to
+ * {
+ *   foo: {
+ *     bar: 'beep'
+ *   }
+ * }
+ *
+ * boring-config wraps node-config, please
+ * refer to node-config's documentation for
+ * more infomration on overriding values
+ * in config files.
+ * https://github.com/lorenwest/node-config
+ */
+
+module.exports = {
+  envrionment: 'none-set',
+  boring: {
+    app: {
+      // This value can be overriden by the evnironment variable PORT
+      port: 5000,
+    },
+    logger: {
+      name: '<%= projectName %>',
+      level: 'info',
+    },
+  },
+};

--- a/yo/generator/server/templates/config/development.js
+++ b/yo/generator/server/templates/config/development.js
@@ -1,0 +1,27 @@
+/**
+ * This file is meant to define
+ * configuration for localhost development.
+ * By default boring assumes development
+ * if there is NO NODE_ENV set.
+ * It is probably best to set your
+ * NODE_ENV=development in your .bashrc
+ * or equiv to be explicit though.
+ *
+ * You should consider this a checked-in
+ * file to your repo so ALL develpers
+ * on the team get the same configuration
+ * defaults for localhost dev.  If a
+ * develop or group of developers want
+ * exotic configs specific to them, then
+ * simply drop am .env file into your project
+ * root and key in an .env will take precednce
+ */
+
+module.exports = {
+  envrionment: 'development',
+  boring: {
+    logger: {
+      level: 'debug',
+    },
+  },
+};

--- a/yo/generator/server/templates/config/production.js
+++ b/yo/generator/server/templates/config/production.js
@@ -1,0 +1,26 @@
+/**
+ * This is your production configuration
+ * file.  You MUST set NODE_ENV=proudction
+ * in order for boring and your program
+ * to be production.
+ *
+ * DO NOT PUT SECRETS HERE.  This file
+ * is intended to be checked in, so
+ * any secrets in source control is
+ * by definition not a secret.
+ * `boring-config` uses `node-config`
+ * under the hood and they have their
+ * own recommendation on managing secrets.  https://github.com/lorenwest/node-config/wiki/Securing-Production-Config-Files
+ *
+ * Depending on your organizations
+ * internal policy on handling secrets,
+ * you can always set environmental
+ * variables where only the system user
+ * running node has access to them. OR
+ * drop a .env file with secrets assuming
+ * you lock down read permissions to that file
+ */
+
+module.exports = {
+  envrionment: 'production',
+};

--- a/yo/generator/server/templates/config/staging.js
+++ b/yo/generator/server/templates/config/staging.js
@@ -1,0 +1,15 @@
+/**
+ * This file is completly optional
+ * and may or may not be used in your
+ * organizaation.  For some shops
+ * (ususally one person shows) having
+ * local development and production
+ * environments is enough.
+ *
+ * To have this config override
+ * keys in default.js set your
+ * NODE_ENV=staging in your system
+ */
+module.exports = {
+  envrionment: 'staging',
+};

--- a/yo/generator/server/templates/server/app.js
+++ b/yo/generator/server/templates/server/app.js
@@ -1,0 +1,10 @@
+const Server = require('boringbits').Server;
+const boring = new Server();
+
+
+boring.start()
+    .then(finalConfig => {
+      // boring has been started, feel free to inspect
+      // the `finalConfig` that also contains the
+      // webpack config used to boot boring
+    });

--- a/yo/package-lock.json
+++ b/yo/package-lock.json
@@ -2505,14 +2505,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2527,20 +2525,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2657,8 +2652,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2670,7 +2664,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2685,7 +2678,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2693,14 +2685,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -2719,7 +2709,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2800,8 +2789,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2813,7 +2801,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2935,7 +2922,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/yo/package.json
+++ b/yo/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "chalk": "^2.1.0",
+    "inquirer": "^6.2.1",
     "yeoman-generator": "^2.0.1",
     "yo": "^2.0.5",
     "yosay": "^2.0.1"


### PR DESCRIPTION
First of many PR's coming to make generators for boring.  The main decision I made was to NOT make a generator project.  I've seen through first hand experience this is a FAST way to make a generator and never maintain it.  So I made it an early design goal to sit the generator code in the *same* project as boring itself, so as you update boring you update the generator with it.  I am open to discussing this decision but this approach has proven to work out fairly well in my testing.

A product of embedding boring generator into boring itself is any boring project can simply generate new parts of their app without having to "go get" the generator, they simply run `npx boring yo` from their command line inside their project. 

I haven't tested this (because we need to push this code to npm to fully test) is in theory people can also generate a whole boring project from scratch by doing `npx boringbits yo`, which technically should install boringbits (the actual name of the project in `npm`) then launch the run script `boring yo` in one fell swoop. 

One side effect of this approach is people DO NOT ever need to know or care they are using yeoman.  Personally I do prefer any "global" tools, and most of the `yo` generators assume both `yo` AND the generator is global.  IMO boring itself takes care of generating whole boring apps or boring components, who cares if it uses yeoman under the hood (as in users do not need `yo` installed globally for this to work). 