### PR TITLE
plumbed react decorators to be access universally

### DIFF
--- a/src/client/core-hooks/react/clientEntry.js
+++ b/src/client/core-hooks/react/clientEntry.js
@@ -60,10 +60,10 @@ function getRootComponents() {
   if (isNode) {
     // putting the path prevents webpack from bundling getNodeRootComponents
     const nodeRootComponents = '../../../lib/init-hooks/core-hooks/react/getNodeRootComponents';
-    return require(nodeRootComponents);
+    return require(nodeRootComponents)();
   } else {
+    __boring_internals.modules.App = __boring_internals.modules.mainApp;
     return {
-      App: __boring_internals.modules.mainApp, // alias
       decorators: __boring_internals.decorators,
       ...__boring_internals.modules,
     };

--- a/src/client/core-hooks/react/clientEntry.js
+++ b/src/client/core-hooks/react/clientEntry.js
@@ -72,11 +72,13 @@ function getRootComponents() {
 };
 
 function subscribeHotReload(fn) {
-  if (!__boring_internals.hot[fn.toString()]) {
-    __boring_internals.hot.subscribe(fn);
-    __boring_internals.hot[fn.toString()] = true;
-    fn();
-  }
+  try {
+    if (!__boring_internals.hot[fn.toString()]) {
+      __boring_internals.hot.subscribe(fn);
+      __boring_internals.hot[fn.toString()] = true;
+      fn();
+    }
+  } catch (e) {}
 }
 
 const toExport = {
@@ -98,6 +100,13 @@ const toExport = {
   subscribeHotReload,
   ...getRootComponents(),
 };
+
+subscribeHotReload(function() {
+  const components = getRootComponents();
+  Object.keys(components).forEach(key => {
+    toExport[key] = components[key];
+  });
+});
 
 toExport['react-redux'] = ReactRedux;
 toExport['react-dom'] = ReactDOM;

--- a/src/lib/init-hooks/core-hooks/context.js
+++ b/src/lib/init-hooks/core-hooks/context.js
@@ -9,10 +9,13 @@ module.exports = function(BoringInjections) {
 
   boring.before('add-hooks', function() {
 
-    const ns = cls.createNamespace('http-request');
+    const ns = cls.getNamespace('http-request');
     boring.after('app.use', function(ctx) {
       if (ctx.name === 'healthy') {
         boring.app.use('context', function contextMiddleware(req, res, next) {
+
+          ns.bindEmitter(req);
+          ns.bindEmitter(res);
 
           ns.run(() => {
             req.corrId = uuid.v4();

--- a/src/lib/init-hooks/core-hooks/react/dynamicComponents/beforeEntryLoader.js
+++ b/src/lib/init-hooks/core-hooks/react/dynamicComponents/beforeEntryLoader.js
@@ -29,7 +29,10 @@ export default function beforeEntryLoader() {
         this.subscribers.push(fn);
       },
       notify: function() {
-        this.subscribers.forEach(fn => fn());
+        this.subscribers.forEach(fn => {
+          console.log('notifying subscriber of a change');
+          fn();
+        });
       },
     };
   } else {

--- a/src/lib/init-hooks/core-hooks/react/dynamicComponents/beforeEntryLoader.js
+++ b/src/lib/init-hooks/core-hooks/react/dynamicComponents/beforeEntryLoader.js
@@ -36,7 +36,11 @@ export default function beforeEntryLoader() {
       },
     };
   } else {
-    internals.hot.notify();
+    setTimeout(() => {
+      // I know this seems jank but it's ONLY
+      // when we are in a partial state because HMR
+      internals.hot.notify();
+    }, 1);
   }
 
   if (module.hot) {

--- a/src/lib/init-hooks/core-hooks/react/dynamicComponents/index.js
+++ b/src/lib/init-hooks/core-hooks/react/dynamicComponents/index.js
@@ -4,7 +4,8 @@ import * as babel from '@babel/core';
 import logger from 'boring-logger';
 import beforeEntryLoader from './beforeEntryLoader';
 
-function makeConainerCode({path, importPath} = container) {
+function makeConainerCode({module, moduleName, importPath} = container) {
+  const path = module.path;
   const name = path.replace(/\//g, '');
 
   return `
@@ -52,7 +53,7 @@ function mapDecorators(decorators) {
 export default function getEntryWrappers(reactRoot, containers = [], modules = {}, decorators = []) {
 
   const filteredContainers = containers
-    .filter(container => container.path)
+    .filter(container => container.module.path)
     .sort((containerA, containerB) => {
       /**
        * This is a reverse sort on the path, the
@@ -64,8 +65,8 @@ export default function getEntryWrappers(reactRoot, containers = [], modules = {
        * will tell me a use case and we'll have to
        * rework this
        */
-      if (containerA.path.length<containerB.path.length) return 1;
-      if (containerA.path.length>containerB.path.length) return -1;
+      if (containerA.module.path.length<containerB.module.path.length) return 1;
+      if (containerA.module.path.length>containerB.module.path.length) return -1;
       return 0;
     });
 

--- a/src/lib/init-hooks/core-hooks/react/dynamicComponents/index.js
+++ b/src/lib/init-hooks/core-hooks/react/dynamicComponents/index.js
@@ -88,10 +88,11 @@ export default function getEntryWrappers(reactRoot, containers = [], modules = {
     const decorators = {};
 
   ` + filteredContainers.map(makeConainerCode).join('\n')
-    + mapModules(modules)
     + mapDecorators(decorators)
-    + beforeEntryLoader.toString()
-    + '\nbeforeEntryLoader();';
+      + beforeEntryLoader.toString()
+      + '\nbeforeEntryLoader();'
+    + mapModules(modules);
+
 
   const babelOptions = {
     'babelrc': false,

--- a/src/lib/init-hooks/core-hooks/react/getNodeRootComponents.js
+++ b/src/lib/init-hooks/core-hooks/react/getNodeRootComponents.js
@@ -1,5 +1,10 @@
+import {getNamespace} from 'boring-cls';
 
-// TODO: magically figure out the right components
-module.exports = {
-  foo: 'bar',
+module.exports = function get() {
+  const ns = getNamespace('http-request');
+  const reactHandlerPaths = ns.get('reactHandlerPaths');
+
+  return {
+    ...reactHandlerPaths,
+  };
 };

--- a/src/lib/init-hooks/core-hooks/react/index.js
+++ b/src/lib/init-hooks/core-hooks/react/index.js
@@ -104,6 +104,7 @@ function reduceMods(mods) {
 function requireDirectory(appDir, directoryPath) {
   const dirToRead = appDir +'/'+ directoryPath;
   try {
+    if (!fs.existsSync(dirToRead)) return [];
     return fs.readdirSync(dirToRead).map(function(file) {
       if (file.endsWith('.map')) return null;
       const moduleName = file.split('.').shift(); // don't worry about what type of extension

--- a/src/lib/init-hooks/core-hooks/react/index.js
+++ b/src/lib/init-hooks/core-hooks/react/index.js
@@ -80,7 +80,9 @@ module.exports = function reactHook(BoringInjections) {
       ctx.res.reactPaths = ctx.get.reactEntry[0];
       ctx.res.renderRedux = renderRedux;
       const reactNS = getNamespace('http-request');
-      reactNS.set('reactHandlerPaths', ctx.res.reactPaths);
+      if (reactNS && reactNS.set) {
+        reactNS.set('reactHandlerPaths', ctx.res.reactPaths);
+      }
     }
 
     return Promise.resolve();

--- a/src/lib/init-hooks/core-hooks/react/reactHandlerPaths.js
+++ b/src/lib/init-hooks/core-hooks/react/reactHandlerPaths.js
@@ -45,7 +45,7 @@ export default function getPaths(options = {}) {
   reactHandlerPaths.modulesToRequire = {};
   const entryPointPath = options.app_dir +'/'+reactHandlerPaths.entrypoint;
 
-  if (!fs.existsSync(reactHandlerPaths.mainApp)) {
+  if (!fs.existsSync(options.app_dir +'/'+ reactHandlerPaths.mainApp)) {
     reactHandlerPaths.mainApp = __dirname + '/defaultRootAppProxy.js';
     reactHandlerPaths.modulesToRequire.mainApp = reactHandlerPaths.mainApp;
   }

--- a/src/lib/init-pipeline.js
+++ b/src/lib/init-pipeline.js
@@ -1,3 +1,5 @@
+import {getNamespace, createNamespace} from 'boring-cls';
+
 const config = require('boring-config');
 const express = require('express');
 const initRouters = require('./init-routers');
@@ -12,11 +14,15 @@ const decorators = require('./decorators')
 const appUseOverride = require('./server/appUseOverride');
 const injecture = require('injecture');
 
+
 class InitPipeline extends EventEmitter  {
 
   constructor() {
     super({wildcard: true});
     Understudy.call(this);
+
+    this.requestNS = createNamespace('http-request');
+
     this.config = config;
     this.logger = logger;
     this.paths = paths;
@@ -32,18 +38,21 @@ class InitPipeline extends EventEmitter  {
     this.app.use = appUseOverride(this.app, perform);
   }
 
+  // eslint-disable-next-line camelcase
   add_middleware(name, middleware) {
-    if (this.middleware[name]) throw new Error('Cannot add middleware with the same key as '+ name)
+    if (this.middleware[name]) throw new Error('Cannot add middleware with the same key as '+ name);
     this.middleware[name] = middleware;
     this.emit('added.middleware', name, middleware);
   }
 
+  // eslint-disable-next-line camelcase
   add_hook(name, hook) {
-    if (this.hooks[name]) throw new Error('Cannot add hook with the same key as '+ name)
+    if (this.hooks[name]) throw new Error('Cannot add hook with the same key as '+ name);
     this.hooks[name] = hook;
     this.emit('added.hook', name, hook);
   }
 
+  // eslint-disable-next-line camelcase
   add_router(router) {
 
     const routePath = router.path || '';

--- a/src/lib/init-routers/index.js
+++ b/src/lib/init-routers/index.js
@@ -148,25 +148,25 @@ function wrapHandler(boring, route, endpoint, methods, method) {
 
     // first execute the middleware
     boring.perform(`http::${method.toLowerCase()}::middleware`,
-        ctx,
-        () => new Promise(function(resolve, reject) {
-          compose(ctx.middleware)(ctx.req, ctx.res, function(err) {
-            if (err) return reject(err);
-            resolve(ctx);
-          });
-
-        }))
-        .then(() => {
-          boring.perform(`http::${method.toLowerCase()}`, ctx, async () => {
-            handler(...[ctx.req, ctx.res, ctx.next]);
-            return ctx;
-          }).catch((e) => {
-            logger.debug(e, `There was rejection from a {{http::${method}}} interceptor for `+url);
-          });
-        })
-        .catch((e) => {
-          logger.debug(e, `There was rejection from a {{http::${method}::middleware}} interceptor for `+url);
+      ctx,
+      () => new Promise(function(resolve, reject) {
+        compose(ctx.middleware)(ctx.req, ctx.res, function(err) {
+          if (err) return reject(err);
+          resolve(ctx);
         });
+
+      }))
+      .then(() => {
+        boring.perform(`http::${method.toLowerCase()}`, ctx, async () => {
+          handler(...[ctx.req, ctx.res, ctx.next]);
+          return ctx;
+        }).catch((e) => {
+          logger.debug(e, `There was rejection from a {{http::${method}}} interceptor for `+url);
+        });
+      })
+      .catch((e) => {
+        logger.debug(e, `There was rejection from a {{http::${method}::middleware}} interceptor for `+url);
+      });
 
   };
 }

--- a/src/lib/server/appUseOverride.js
+++ b/src/lib/server/appUseOverride.js
@@ -9,10 +9,10 @@ module.exports = function(app, perform) {
       name = middleware.name; // just use the name of the function
     }
 
-    let ctx = {
+    const ctx = {
       middleware,
       name,
-    }
+    };
 
     oldUse(deferMiddleware(name, new Promise(function(resolve, reject) {
 
@@ -30,11 +30,9 @@ module.exports = function(app, perform) {
         return ctx;
       }).catch(reject);
 
-    })))
-
-   };
-
-}
+    })));
+  };
+};
 
 function deferMiddleware(name, middlewarePromise) {
 
@@ -46,6 +44,6 @@ function deferMiddleware(name, middlewarePromise) {
       deferedMiddleware(req, res, next);
     }).catch((e) => {
       throw e;
-    })
-  }
+    });
+  };
 }

--- a/src/lib/server/appUseOverride.js
+++ b/src/lib/server/appUseOverride.js
@@ -16,7 +16,7 @@ module.exports = function(app, perform) {
 
     oldUse(deferMiddleware(name, new Promise(function(resolve, reject) {
 
-      logger.info('Registering middielware::' + ctx.name);
+      logger.info('Registering middleware::' + ctx.name);
       perform('app.use', ctx, async function() {
         // This in a way acts a dependency
         // system where a hook can only

--- a/src/node_modules/boring-cls/test/boring-cls-test.js
+++ b/src/node_modules/boring-cls/test/boring-cls-test.js
@@ -61,11 +61,12 @@ function requestHandler(str) {
   });
 }
 
-function make(writer) {
+function make() {
 
   return new Promise((resolve, reject) => {
     setTimeout(() => {
 
+      const writer = cls.getNamespace('writer');
       writer.run(function() {
         writer.set('value', 0);
 
@@ -88,7 +89,7 @@ function make(writer) {
   }, Math.round(Math.random() * 100)); // make each request "random" within 100 ms of each other
 }
 
-describe.only('boring-cls', function() {
+describe('boring-cls', function() {
 
   // eslint-disable-next-line no-invalid-this
   this.timeout(10000);
@@ -125,7 +126,7 @@ describe.only('boring-cls', function() {
     const promises = [];
 
     const writer = cls.createNamespace('writer');
-    for (let i =0; i<1000; i++) promises.push(make(writer));
+    for (let i =0; i<1000; i++) promises.push(make());
     Promise.all(promises).then(results => {
 
       results.forEach(result => {


### PR DESCRIPTION
Ooookayy.  This is probably the most magically commit I've ever made in boring.  Essentially I've plumbed in a way for containers to have access to decorators simply by doing 

`import { decorators } from 'boringbits/react`

The decorator object is constructed by sweeping through the directory `decorators` where the key is the filename and value is whatever the module exports.  Each decorator is assumed to be a class that is meant to take a React Class as an argument and render it as a child.  

The way I make the object available magically on the client side is simply re-using the same mechanism / glue I used to include all modules in the "containers" directory.  
 
Making the decorators available on the node side is a bit more complicated.  Essentially the problem is importing from `boringbits/react` is a single file and that has no way of knowing "which" set of decorators that page needs.  IF boring were only to support one and only one SPA, then there would be no problem  But because boring supports many independent pages, each with their own set of potential decorators (or some sharing subsets), a require to a single file becomes problematic as it must return the set of decorators to a container in _it's own_ "page".  

The way I choose to solve this is rely upon hooked-cls and piggyback off the `http-request` namespace.  Essentially when any react component is required on the node side it will be done via a HTTP Request (obviously), and the `context` plugin already has the ability to pull information out of CLS (equiv to thread local storage).  

This PR essentially does two things, it puts an object into the `http-request` CLS namespace called `reactHandlerPaths` which has all the meta data the `@reactEntry` decorator created (which includes all the modules "magically" required per route / page.  Then `boringbits/react` has an exposed function `getRootComponents` which will either lookup from CLS on the node side or `__boring_internals` on the client side. 

